### PR TITLE
refactor(story-3-6): DailyCommitment uses context, removes progress p…

### DIFF
--- a/docs/business-requirements/epic-3-state-management-refactor-template/story-3-6-refactor-dailycommitment-template.md
+++ b/docs/business-requirements/epic-3-state-management-refactor-template/story-3-6-refactor-dailycommitment-template.md
@@ -6,7 +6,7 @@ Refactor the `DailyCommitment` component to consume Mandarin context directly, r
 
 ## Status
 
-Planned
+Completed
 
 ## Epic Reference
 

--- a/docs/issue-implementation/epic-3-state-management-refactor/story-3-6-refactor-dailycommitment.md
+++ b/docs/issue-implementation/epic-3-state-management-refactor/story-3-6-refactor-dailycommitment.md
@@ -1,37 +1,30 @@
 # Story 3-6: Refactor DailyCommitment to Use Context
 
-## Story Summary
+## Technical Scope
 
-Refactor the `DailyCommitment` component to consume Mandarin context directly, removing all progress-related props.
+Refactor the `DailyCommitment` component to consume Mandarin context directly, removing all progress-related props and handling navigation via a callback prop.
 
-## Background
+## Implementation Details
 
-Direct context consumption eliminates prop drilling and simplifies the component interface.
+- Removed all progress-related props from `DailyCommitment` except for the optional `onConfirm` callback.
+- All state and actions (selectedList, selectedWords, inputValue, setInputValue, dailyWordCount, saveCommitment, loading, error) are now accessed via `useMandarinContext`.
+- Persistence and progress logic are managed by the context/hook, not the component.
+- Navigation to the next page is triggered by the `onConfirm` callback, passed from the parent (`Mandarin.tsx`).
+- Updated file-level comments to reflect the new architecture.
 
-## Acceptance Criteria
+## Architecture Integration
 
-- `DailyCommitment` uses the consumer hook for all state/actions
-- All progress-related props are removed
-- Component functionality remains unchanged
+- `DailyCommitment` is now fully decoupled from parent state and props, integrating with the broader system via context and hooks.
+- The refactor aligns with the Epic 3 goal of eliminating prop drilling and centralizing state management.
+- All progress and persistence logic is handled in `useMandarinProgress` and `ProgressContext`.
 
-## Dependencies
+## Technical Challenges & Solutions
 
-Story 3-4: Create Consumer Hook and Add Types
+- **Challenge:** Ensuring navigation after commitment confirmation without direct parent state access.
+  **Solution:** Added an `onConfirm` callback prop to trigger navigation from the parent.
+- **Challenge:** Maintaining identical functionality after removing props.
+  **Solution:** Verified that all state/actions are available via context and updated tests/manual checks.
 
-## Related Issues
+## References
 
-Epic 3: State Management Refactor
-
----
-
-# Implementation Plan
-
-1. Update `DailyCommitment` to use the consumer hook
-2. Remove all progress-related props
-3. Verify component works as expected
-
----
-
-# Technical Implementation Reference
-
-See [Epic 3 Technical Doc](./README.md)
+- See [Epic 3 Technical Doc](./README.md)

--- a/src/features/mandarin/components/DailyCommitment.tsx
+++ b/src/features/mandarin/components/DailyCommitment.tsx
@@ -2,33 +2,28 @@
  * DailyCommitment component
  *
  * - Allows user to set and save a daily word study goal for the selected list.
- * - Receives selectedList, selectedWords, inputValue, and handlers as props.
- * - Pure presentational; does not manage persistence or parent state.
+ * - Uses Mandarin context for all state and actions (no props required).
+ * - Manages persistence and progress via context and hooks.
  * - Validates input and displays estimated days to complete.
  */
 
-type Props = {
-  selectedList: string | null;
-  selectedWords: any[];
-  inputValue: string;
-  setInputValue: any;
-  dailyWordCount: number | null;
-  handleCommitmentSave: any;
-  loading: boolean;
-  error: string;
+import { useMandarinContext } from "../context/useMandarinContext";
+
+type DailyCommitmentProps = {
+  onConfirm?: () => void;
 };
 
-export function DailyCommitment({
-  selectedList,
-  selectedWords,
-  inputValue,
-  setInputValue,
-  dailyWordCount,
-  handleCommitmentSave,
-  loading,
-  error,
-}: Props) {
-  // ...existing code...
+export function DailyCommitment({ onConfirm }: DailyCommitmentProps) {
+  const {
+    selectedList,
+    selectedWords,
+    inputValue,
+    setInputValue,
+    dailyWordCount,
+    saveCommitment,
+    loading,
+    error,
+  } = useMandarinContext();
 
   // Recommended range
   const recommendedMin = 5;
@@ -66,7 +61,14 @@ export function DailyCommitment({
       />
       <button
         type="button"
-        onClick={handleCommitmentSave}
+        onClick={() => {
+          if (isInputValid) {
+            saveCommitment(inputNum);
+            if (onConfirm) {
+              onConfirm();
+            }
+          }
+        }}
         disabled={!isInputValid || loading}
         style={{ marginLeft: 8 }}
       >

--- a/src/features/mandarin/docs/design.md
+++ b/src/features/mandarin/docs/design.md
@@ -38,8 +38,8 @@ The Mandarin feature provides vocabulary learning, flashcards, review, and daily
 ## 3. State Management & Architecture
 
 - Uses React Context API (`ProgressContext`, `useMandarinContext`) and custom hooks (`useMandarinProgress`) for shared state and progress tracking
-- Components (e.g., `VocabularyListSelector`) consume context directly, eliminating prop drilling
-- Navigation between sections/components via callback props for parent-driven control
+- Components (e.g., `VocabularyListSelector`, `DailyCommitment`) consume context directly, eliminating prop drilling
+- Navigation between sections/components (e.g., after confirming daily commitment) is handled via callback props for parent-driven control
 - Atomic story-driven workflow: each story implements a focused change
 - Documentation separation: high-level in epic docs, detailed in story docs
 


### PR DESCRIPTION
…rops, navigation via callback

Story 3-6: Refactor DailyCommitment to use context.
- DailyCommitment now consumes context for all state/actions, removes all progress-related props.
- Navigation after commitment confirmation handled via callback prop.
- Updated Mandarin.tsx, useMandarinProgress.ts, and related documentation.